### PR TITLE
ensure dulplicate emit added problems

### DIFF
--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -180,7 +180,10 @@ public class Trie {
         Collection<String> emits = currentState.emit();
         if (emits != null && !emits.isEmpty()) {
             for (String emit : emits) {
-                collectedEmits.add(new Emit(position-emit.length()+1, position, emit));
+                Emit element = new Emit(position - emit.length() + 1, position, emit);
+                if (!collectedEmits.contains(element)) {
+                    collectedEmits.add(element);
+                }
             }
         }
     }


### PR DESCRIPTION
Hi, i find that aho-corasick load text again and again.
Examples below :

```
    @RequestMapping(value = "/mss/redis", produces = "application/json")
    @ResponseBody
    public Collection<Emit> redis() {
//         return multipleStringSearchService.ahocorasickMethod("matchest",
//         "anjuke_prop", "anjuke, community");
        return ahocorasickMethod("matchest", "anjuke_prop", "anjuke, community");
    }

    public Collection<Emit> ahocorasickMethod(String method, String dicname,
            String text) {
        Trie trie = METHODS.get(method);
        Set<String> allKeys = redisService.getAllKeys(dicname);
        for (String key : allKeys) {
            trie.addKeyword(key);
        }
        // return new HashSet<Emit>(trie.parseText(text));
        return trie.parseText(text);
    }
```

i got the result : 

```
[
  {
      start : 0,
      end : 5,
      keyword : "anjuke"
  }
  {
      start : 8,
      end : 16,
      keyword : "community"
  }
]
```

Then i refreshed the web, i got the belowing : 

```
[
  {
      start : 0,
      end : 5,
      keyword : "anjuke"
  }
  {
      start : 0,
      end : 5,
      keyword : "anjuke"
  }
  {
      start : 8,
      end : 16,
      keyword : "community"
  }
 {
      start : 8,
      end : 16,
      keyword : "community"
  }
]
```

i suppose that in Trie.java, method 'storeEmits' makes 'Collection<String> emits' on RAM, but i've not found out the principle.
i fixed it on the commits 'ensure dulplicate emit added problems', i hope we can make it better.
