### PR TITLE
add onlyWholeWordsWhiteSpace separated option

### DIFF
--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -46,6 +46,11 @@ public class Trie {
         return this;
     }
 
+    public Trie onlyWholeWordsWhiteSpaceSeparated() {
+        this.trieConfig.setOnlyWholeWordsWhiteSpaceSeparated(true);
+        return this;
+    }
+
     public void addKeyword(String keyword) {
         if (keyword == null || keyword.length() == 0) {
             return;
@@ -105,6 +110,10 @@ public class Trie {
             removePartialMatches(text, collectedEmits);
         }
 
+        if (trieConfig.isOnlyWholeWordsWhiteSpaceSeparated()) {
+            removePartialMatchesWhiteSpaceSeparated(text, collectedEmits);
+        }
+
         if (!trieConfig.isAllowOverlaps()) {
             IntervalTree intervalTree = new IntervalTree((List<Intervalable>)(List<?>)collectedEmits);
             intervalTree.removeOverlaps((List<Intervalable>) (List<?>) collectedEmits);
@@ -121,6 +130,24 @@ public class Trie {
                  !Character.isAlphabetic(searchText.charAt(emit.getStart() - 1))) &&
                 (emit.getEnd() + 1 == size ||
                  !Character.isAlphabetic(searchText.charAt(emit.getEnd() + 1)))) {
+                continue;
+            }
+            removeEmits.add(emit);
+        }
+
+        for (Emit removeEmit : removeEmits) {
+            collectedEmits.remove(removeEmit);
+        }
+    }
+
+    private void removePartialMatchesWhiteSpaceSeparated(String searchText, List<Emit> collectedEmits) {
+        long size = searchText.length();
+        List<Emit> removeEmits = new ArrayList<Emit>();
+        for (Emit emit : collectedEmits) {
+            if ((emit.getStart() == 0 ||
+                    Character.isWhitespace(searchText.charAt(emit.getStart() - 1))) &&
+                    (emit.getEnd() + 1 == size ||
+                            Character.isWhitespace(searchText.charAt(emit.getEnd() + 1)))) {
                 continue;
             }
             removeEmits.add(emit);

--- a/src/main/java/org/ahocorasick/trie/TrieConfig.java
+++ b/src/main/java/org/ahocorasick/trie/TrieConfig.java
@@ -6,6 +6,8 @@ public class TrieConfig {
 
     private boolean onlyWholeWords = false;
 
+    private boolean onlyWholeWordsWhiteSpaceSeparated = false;
+
     private boolean caseInsensitive = false;
 
     public boolean isAllowOverlaps() {
@@ -31,4 +33,8 @@ public class TrieConfig {
     public void setCaseInsensitive(boolean caseInsensitive) {
         this.caseInsensitive = caseInsensitive;
     }
+
+    public boolean isOnlyWholeWordsWhiteSpaceSeparated() { return onlyWholeWordsWhiteSpaceSeparated; }
+
+    public void setOnlyWholeWordsWhiteSpaceSeparated(boolean onlyWholeWordsWhiteSpaceSeparated) { this.onlyWholeWordsWhiteSpaceSeparated = onlyWholeWordsWhiteSpaceSeparated;}
 }

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -134,6 +134,15 @@ public class TrieTest {
     }
 
     @Test
+    public void partialMatchWhiteSpaces() {
+        Trie trie = new Trie().onlyWholeWordsWhiteSpaceSeparated();
+        trie.addKeyword("#sugar-123");
+        Collection<Emit> emits = trie.parseText("#sugar-123 #sugar-1234"); // left, middle, right test
+        assertEquals(1, emits.size()); // Match must not be made
+        checkEmit(emits.iterator().next(), 0, 9, "#sugar-123");
+    }
+
+    @Test
     public void tokenizeFullSentence() {
         Trie trie = new Trie();
         trie.addKeyword("Alpha");


### PR DESCRIPTION
*onlyWholeWords* seems to be related to alphabetic characters. This option does not work well if our keyword is "sugar-123" for instance.

I suggest a more flexible option, *onlyWholeWordsWhiteSpace*, intented to match elements separated by whitespace characters, and tolerant to numeric and punctuation ones.

