### PR TITLE
Implement word transitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.ahocorasick</groupId>
     <artifactId>ahocorasick</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.3.1-heartbeat</version>
     <packaging>jar</packaging>
     <name>Aho-CoraSick algorithm for efficient string matching</name>
     <description>Java library for efficient string matching against a large set of keywords</description>

--- a/src/main/java/org/ahocorasick/trie/CharacterTransition.java
+++ b/src/main/java/org/ahocorasick/trie/CharacterTransition.java
@@ -26,7 +26,7 @@ class CharacterTransition extends Transition<Character> {
     }
 
     @Override
-    public void updateMatch(StringBuffer match) {
+    public void updateMatch(StringBuilder match) {
         match.append(token);
     }
 

--- a/src/main/java/org/ahocorasick/trie/CharacterTransition.java
+++ b/src/main/java/org/ahocorasick/trie/CharacterTransition.java
@@ -31,7 +31,7 @@ class CharacterTransition extends Transition<Character> {
 
     @Override
     public boolean isWordSeparator() {
-        return Character.isSpaceChar(token);
+        return Character.isWhitespace(token);
     }
     
 }

--- a/src/main/java/org/ahocorasick/trie/CharacterTransition.java
+++ b/src/main/java/org/ahocorasick/trie/CharacterTransition.java
@@ -21,13 +21,12 @@ package org.ahocorasick.trie;
  */
 class CharacterTransition extends Transition<Character> {
 
-    public CharacterTransition(Character c) {
-        super(c);
+    public CharacterTransition(Character c, int start) {
+        super(c, start, 1);
     }
 
-    @Override
-    public void updateMatch(StringBuilder match) {
-        match.append(token);
+    public CharacterTransition(Character c) {
+        this(c, 0);
     }
 
     @Override

--- a/src/main/java/org/ahocorasick/trie/CharacterTransition.java
+++ b/src/main/java/org/ahocorasick/trie/CharacterTransition.java
@@ -16,19 +16,23 @@
 package org.ahocorasick.trie;
 
 /**
- * Enables the trie to model transitions on whole words or characters
- * ... or whatever!
+ * Model transitions on characters
  * @author doug.lovell
- * @param <T>
  */
-public abstract class Transition<T> {
-    protected final T token;
-    public Transition(T token) {
-        this.token = token;
+class CharacterTransition extends Transition<Character> {
+
+    public CharacterTransition(Character c) {
+        super(c);
     }
-    public T transitionToken() {
-        return token;
+
+    @Override
+    public void updateMatch(StringBuffer match) {
+        match.append(token);
     }
-    public abstract void updateMatch(StringBuffer match);
-    public abstract boolean isWordSeparator();
+
+    @Override
+    public boolean isWordSeparator() {
+        return Character.isSpaceChar(token);
+    }
+    
 }

--- a/src/main/java/org/ahocorasick/trie/CharacterTransition.java
+++ b/src/main/java/org/ahocorasick/trie/CharacterTransition.java
@@ -29,9 +29,4 @@ class CharacterTransition extends Transition<Character> {
         this(c, 0);
     }
 
-    @Override
-    public boolean isWordSeparator() {
-        return Character.isWhitespace(token);
-    }
-    
 }

--- a/src/main/java/org/ahocorasick/trie/Emit.java
+++ b/src/main/java/org/ahocorasick/trie/Emit.java
@@ -6,14 +6,25 @@ import org.ahocorasick.interval.Intervalable;
 public class Emit extends Interval implements Intervalable {
 
     private final String keyword;
+    private final boolean isWholeWord;
 
-    public Emit(final int start, final int end, final String keyword) {
+    public Emit(final int start, final int end, 
+            final String keyword, boolean isWholeWord) {
         super(start, end);
         this.keyword = keyword;
+        this.isWholeWord = isWholeWord;
+    }
+    
+    public Emit(final int start, final int end, final String keyword) {
+        this(start, end, keyword, true);
     }
 
     public String getKeyword() {
         return this.keyword;
+    }
+    
+    public boolean isWholeWord() {
+        return isWholeWord;
     }
 
     @Override

--- a/src/main/java/org/ahocorasick/trie/Emit.java
+++ b/src/main/java/org/ahocorasick/trie/Emit.java
@@ -6,27 +6,16 @@ import org.ahocorasick.interval.Intervalable;
 public class Emit extends Interval implements Intervalable {
 
     private final String keyword;
-    private final boolean isWholeWord;
 
-    public Emit(final int start, final int end, 
-            final String keyword, boolean isWholeWord) {
+    public Emit(final int start, final int end, final String keyword) {
         super(start, end);
         this.keyword = keyword;
-        this.isWholeWord = isWholeWord;
     }
     
-    public Emit(final int start, final int end, final String keyword) {
-        this(start, end, keyword, true);
-    }
-
     public String getKeyword() {
         return this.keyword;
     }
     
-    public boolean isWholeWord() {
-        return isWholeWord;
-    }
-
     @Override
     public String toString() {
         return super.toString() + "=" + this.keyword;

--- a/src/main/java/org/ahocorasick/trie/FragmentToken.java
+++ b/src/main/java/org/ahocorasick/trie/FragmentToken.java
@@ -2,16 +2,8 @@ package org.ahocorasick.trie;
 
 public class FragmentToken extends Token {
 
-    private boolean whiteSpace;
-
     public FragmentToken(String fragment) {
         super(fragment);
-        this.whiteSpace = true;
-        for (int position = 0; position < fragment.length(); position++) {
-            if (!Character.isWhitespace(fragment.charAt(position))) {
-                whiteSpace = false;
-            }
-        }
     }
 
     @Override
@@ -22,11 +14,6 @@ public class FragmentToken extends Token {
     @Override
     public Emit getEmit() {
         return null;
-    }
-
-    @Override
-    public boolean isWhiteSpace() {
-        return whiteSpace;
     }
 
 }

--- a/src/main/java/org/ahocorasick/trie/Keyword.java
+++ b/src/main/java/org/ahocorasick/trie/Keyword.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Rogue Wave Software.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ahocorasick.trie;
+
+/**
+ *
+ * @author doug.lovell
+ */
+public class Keyword implements Comparable {
+    private final String text;
+    private int depth;
+    
+    public Keyword(String text, int depth) {
+        this.text = text;
+        this.depth = depth;
+    }
+    
+    public void setDepth(int depth) {
+        this.depth = depth;
+    }
+    
+    public int getDepth() {
+        return depth;
+    }
+    
+    public String getText() {
+        return text;
+    }
+    
+    public String toString() {
+        return "Keyword '" + text + "' at depth " + depth;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        if (o instanceof Keyword) {
+            return text.compareTo(((Keyword) o).text);
+        }
+        throw new IllegalArgumentException("Only supports comparison with other keywords");
+    }
+}

--- a/src/main/java/org/ahocorasick/trie/MatchToken.java
+++ b/src/main/java/org/ahocorasick/trie/MatchToken.java
@@ -10,11 +10,6 @@ public class MatchToken extends Token {
     }
 
     @Override
-    public boolean isWholeWord() {
-        return emit.isWholeWord();
-    }
-
-    @Override
     public boolean isMatch() {
         return true;
     }

--- a/src/main/java/org/ahocorasick/trie/MatchToken.java
+++ b/src/main/java/org/ahocorasick/trie/MatchToken.java
@@ -2,19 +2,16 @@ package org.ahocorasick.trie;
 
 public class MatchToken extends Token {
 
-    private final boolean wholeWord;
-
     private final Emit emit;
 
-    public MatchToken(String fragment, Emit emit, boolean wholeWord) {
+    public MatchToken(String fragment, Emit emit) {
         super(fragment);
         this.emit = emit;
-        this.wholeWord = wholeWord;
     }
 
     @Override
     public boolean isWholeWord() {
-        return wholeWord;
+        return emit.isWholeWord();
     }
 
     @Override

--- a/src/main/java/org/ahocorasick/trie/State.java
+++ b/src/main/java/org/ahocorasick/trie/State.java
@@ -43,7 +43,7 @@ public class State {
     private State failure = null;
 
     /** whenever this state is reached, it will emit the matches keywords for future reference */
-    private Set<String> emits = null;
+    private Set<Keyword> emits = null;
 
     public State() {
         this(0);
@@ -83,21 +83,25 @@ public class State {
         return this.depth;
     }
 
-    public void addEmit(String keyword) {
+    public void addEmit(Keyword keyword) {
         if (this.emits == null) {
             this.emits = new TreeSet<>();
         }
         this.emits.add(keyword);
     }
 
-    public void addEmit(Collection<String> emits) {
-        for (String emit : emits) {
+    public void addEmit(Collection<Keyword> emits) {
+        for (Keyword emit : emits) {
             addEmit(emit);
         }
     }
+    
+    public void addEmitString(String key) {
+        addEmit(new Keyword(key, depth));
+    }
 
-    public Collection<String> emit() {
-        return this.emits == null ? Collections.<String> emptyList() : this.emits;
+    public Collection<Keyword> emit() {
+        return this.emits == null ? Collections.<Keyword> emptyList() : this.emits;
     }
 
     public State failure(EmitCandidateFlushHandler emitCandidateFlushHandler) {

--- a/src/main/java/org/ahocorasick/trie/State.java
+++ b/src/main/java/org/ahocorasick/trie/State.java
@@ -10,8 +10,8 @@ import java.util.*;
  * </p>
  *
  * <ul>
- *     <li>success; when a character points to another state, it must return that state</li>
- *     <li>failure; when a character has no matching state, the algorithm must be able to fall back on a
+ *     <li>success; when a transition points to another state, it must return that state</li>
+ *     <li>failure; when a transition has no matching state, the algorithm must be able to fall back on a
  *         state with less depth</li>
  *     <li>emits; when this state is passed and keywords have been matched, the matches must be
  *         'emitted' so that they can be used later on.</li>
@@ -19,7 +19,7 @@ import java.util.*;
  *
  * <p>
  *     The root state is special in the sense that it has no failure state; it cannot fail. If it 'fails'
- *     it will still parse the next character and start from the root node. This ensures that the algorithm
+ *     it will still parse the next transition and start from the root node. This ensures that the algorithm
  *     always runs. All other states always have a fail state.
  * </p>
  *
@@ -35,9 +35,9 @@ public class State {
 
     /**
      * referred to in the white paper as the 'goto' structure. From a state it is possible to go
-     * to other states, depending on the character passed.
+     * to other states, depending on the transition passed.
      */
-    private Map<Character,State> success = new HashMap<Character, State>();
+    private final Map<Transition,State> success = new HashMap<>();
 
     /** if no matching states are found, the failure state will be returned */
     private State failure = null;
@@ -54,27 +54,27 @@ public class State {
         this.rootState = depth == 0 ? this : null;
     }
 
-    private State nextState(Character character, boolean ignoreRootState) {
-        State nextState = this.success.get(character);
+    private State nextState(Transition t, boolean ignoreRootState) {
+        State nextState = this.success.get(t);
         if (!ignoreRootState && nextState == null && this.rootState != null) {
             nextState = this.rootState;
         }
         return nextState;
     }
 
-    public State nextState(Character character) {
-        return nextState(character, false);
+    public State nextState(Transition t) {
+        return nextState(t, false);
     }
 
-    public State nextStateIgnoreRootState(Character character) {
-        return nextState(character, true);
+    public State nextStateIgnoreRootState(Transition t) {
+        return nextState(t, true);
     }
 
-    public State addState(Character character) {
-        State nextState = nextStateIgnoreRootState(character);
+    public State addState(Transition t) {
+        State nextState = nextStateIgnoreRootState(t);
         if (nextState == null) {
             nextState = new State(this.depth+1);
-            this.success.put(character, nextState);
+            this.success.put(t, nextState);
         }
         return nextState;
     }
@@ -119,7 +119,7 @@ public class State {
         return this.success.values();
     }
 
-    public Collection<Character> getTransitions() {
+    public Collection<Transition> getTransitions() {
         return this.success.keySet();
     }
 

--- a/src/main/java/org/ahocorasick/trie/Token.java
+++ b/src/main/java/org/ahocorasick/trie/Token.java
@@ -2,7 +2,7 @@ package org.ahocorasick.trie;
 
 public abstract class Token {
 
-    private String fragment;
+    private final String fragment;
 
     public Token(String fragment) {
         this.fragment = fragment;
@@ -13,14 +13,6 @@ public abstract class Token {
     }
 
     public abstract boolean isMatch();
-
-    public boolean isWholeWord() {
-        return false;
-    }
-
-    public boolean isWhiteSpace() {
-        return false;
-    }
 
     public abstract Emit getEmit();
 

--- a/src/main/java/org/ahocorasick/trie/Tokenizer.java
+++ b/src/main/java/org/ahocorasick/trie/Tokenizer.java
@@ -9,7 +9,7 @@ public class Tokenizer {
     private final Collection<Emit> emits;
 
     private final String text;
-
+    
     public Tokenizer(Collection<Emit> emits, String text) {
         this.emits = emits;
         this.text = text;

--- a/src/main/java/org/ahocorasick/trie/Tokenizer.java
+++ b/src/main/java/org/ahocorasick/trie/Tokenizer.java
@@ -40,8 +40,7 @@ public class Tokenizer {
     private Token createMatch(Emit emit, String text) {
         return new MatchToken(
                 text.substring(emit.getStart(), emit.getEnd()+1),
-                emit,
-                Trie.isWholeWord(this.text, emit.getStart(), emit.getEnd()));
+                emit);
     }
 
 }

--- a/src/main/java/org/ahocorasick/trie/Transition.java
+++ b/src/main/java/org/ahocorasick/trie/Transition.java
@@ -29,6 +29,6 @@ public abstract class Transition<T> {
     public T transitionToken() {
         return token;
     }
-    public abstract void updateMatch(StringBuffer match);
+    public abstract void updateMatch(StringBuilder match);
     public abstract boolean isWordSeparator();
 }

--- a/src/main/java/org/ahocorasick/trie/Transition.java
+++ b/src/main/java/org/ahocorasick/trie/Transition.java
@@ -15,6 +15,8 @@
  */
 package org.ahocorasick.trie;
 
+import java.util.Objects;
+
 /**
  * Enables the trie to model transitions on whole words or characters
  * ... or whatever!
@@ -23,12 +25,37 @@ package org.ahocorasick.trie;
  */
 public abstract class Transition<T> {
     protected final T token;
+    
     public Transition(T token) {
         this.token = token;
     }
+    
     public T transitionToken() {
         return token;
     }
+    
     public abstract void updateMatch(StringBuilder match);
     public abstract boolean isWordSeparator();
+    
+    @Override
+    public String toString() {
+        return "Transition on " + token;
+    }
+    
+    @Override
+    public int hashCode() {
+        return token.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Transition<?> other = (Transition<?>) obj;
+        return Objects.equals(this.token, other.token);
+    }
 }

--- a/src/main/java/org/ahocorasick/trie/Transition.java
+++ b/src/main/java/org/ahocorasick/trie/Transition.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  * @author doug.lovell
  * @param <T>
  */
-public abstract class Transition<T> {
+public class Transition<T> {
     protected final T token;
     protected final int start;
     protected final int length;
@@ -46,11 +46,10 @@ public abstract class Transition<T> {
         return length;
     }
     
-    public abstract boolean isWordSeparator();
-    
     @Override
     public String toString() {
-        return "Transition on " + token;
+        return "Transition on '" + token + "' start: " + start +
+                ", length: " + length;
     }
     
     @Override

--- a/src/main/java/org/ahocorasick/trie/Transition.java
+++ b/src/main/java/org/ahocorasick/trie/Transition.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Rogue Wave Software.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ahocorasick.trie;
+
+/**
+ * Enables the trie to model transitions on whole words or characters
+ * ... or whatever!
+ * @author doug.lovell
+ * @param <T>
+ */
+public class Transition<T> {
+    private final T token;
+    public Transition(T token) {
+        this.token = token;
+    }
+    public T transitionToken() {
+        return token;
+    }
+    public boolean isWordSeparator() {
+        return (!(token instanceof Character) ||
+                Character.isSpaceChar((Character)token));
+    }
+}

--- a/src/main/java/org/ahocorasick/trie/Transition.java
+++ b/src/main/java/org/ahocorasick/trie/Transition.java
@@ -25,16 +25,27 @@ import java.util.Objects;
  */
 public abstract class Transition<T> {
     protected final T token;
+    protected final int start;
+    protected final int length;
     
-    public Transition(T token) {
+    public Transition(T token, int start, int length) {
         this.token = token;
+        this.start = start;
+        this.length = length;
     }
     
     public T transitionToken() {
         return token;
     }
     
-    public abstract void updateMatch(StringBuilder match);
+    public int getStart() {
+        return start;
+    }
+    
+    public int getLength() {
+        return length;
+    }
+    
     public abstract boolean isWordSeparator();
     
     @Override

--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -45,7 +45,6 @@ public class Trie {
         public int getPosition() {
             return position;
         }
-        public abstract Emit match(Keyword kwd, int start, int position);
     }
     
     private class WordTokenizer extends KeywordTokenizer {
@@ -68,15 +67,6 @@ public class Trie {
             }
             return t;
         }
-        /*
-        On word matching, we return the matched text, which can be of different
-        length that the keyword, due to whitespace differences.
-        */
-        @Override
-        public Emit match(Keyword kwd, int start, int position) {
-            String matchedText = input.subSequence(start, position).toString();
-            return new Emit(start, position - 1, matchedText);
-        }
     }
     
     private class CharacterTokenizer extends KeywordTokenizer {
@@ -91,14 +81,6 @@ public class Trie {
                 position += 1;
             }
             return t;
-        }
-        /*
-        On character matching, the tests expect the implementation to
-        return the matched keyword.
-        */
-        @Override
-        public Emit match(Keyword kwd, int start, int position) {
-            return new Emit(start, position - 1, kwd.getText());
         }
     }
     
@@ -136,10 +118,6 @@ public class Trie {
         
         public String input() {
             return input.toString();
-        }
-        
-        public Emit match(Keyword kwd, int start, int position) {
-            return kwt.match(kwd, start, position);
         }
 
     }
@@ -209,7 +187,8 @@ public class Trie {
                 int position = tn.getStart() + tn.getLength();
                 int start = tknHistory.get(depth - emit.getDepth()).getStart();
                 ListIterator<Transition> tns = tknHistory.listIterator();
-                emitCandidateHolder.addCandidate(tknz.match(emit, start, position));
+                emitCandidateHolder.addCandidate(
+                        new Emit(start, position - 1, emit.getText()));
             }
             tn = tknz.nextTransition();
         }

--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -222,6 +222,8 @@ public class Trie {
         private final TrieConfig trieConfig = new TrieConfig();
 
         private final Trie trie = new Trie(trieConfig);
+        
+        private boolean hasAddedKeyword = false;
 
         private TrieBuilder() {}
 
@@ -240,11 +242,21 @@ public class Trie {
             return this;
         }
 
-        public TrieBuilder addKeyword(String keyword) {
-            trie.addKeyword(keyword);
+        public TrieBuilder wordTransitions() {
+            if (hasAddedKeyword) {
+                throw new IllegalStateException(
+                    "Unable to switch to word transitions after keywords added");
+            }
+            this.trieConfig.setWordTransitions(true);
             return this;
         }
 
+        public TrieBuilder addKeyword(String keyword) {
+            trie.addKeyword(keyword);
+            hasAddedKeyword = true;
+            return this;
+        }
+        
         public Trie build() {
             trie.constructFailureStates();
             return trie;

--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -32,8 +32,6 @@ public class Trie {
         public Transition nextTransition();
     }
     
-    
-    
     private class WordTokenizer implements KeywordTokenizer {
         private final java.util.StringTokenizer st;
         public WordTokenizer(String keyword) {
@@ -58,7 +56,7 @@ public class Trie {
     
     private KeywordTokenizer keywordTokenizer(String keyword) {
         KeywordTokenizer kwt;
-        if (trieConfig.hasOnlyWordNodes()) {
+        if (trieConfig.hasWordTransitions()) {
             kwt = new WordTokenizer(keyword);
         }
         else {

--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -48,10 +48,29 @@ public class Trie {
     private class WordTokenizer extends KeywordTokenizer {
         public WordTokenizer(CharSequence input) {
             super(input);
+            System.out.println("WORDTOKENIZER input '" + input + "'");
+            // leading and trailing white space cannot be part of the
+            // search pattern
+            int start = 0;
+            while (start < length && Character.isWhitespace(input.charAt(start))) {
+                ++start;
+            }
+            int end = length - 1;
+            while (start < end && Character.isWhitespace(input.charAt(end))) {
+                --end;
+            }
+            this.input = input.subSequence(start, end + 1);
+            this.length = end - start + 1;
+            System.out.println("WORDTOKENIZER input '" + this.input + "'");
+            System.out.println("input.length " + this.input.length() + ", this.length " + this.length);
         }
         @Override
         public Transition<String> nextTransition() {
             WordTransition t = null;
+            System.out.println("WORDTOKENIZER get next word transition");
+            System.out.println("Position: " + position);
+            System.out.println("Text under cursor, '" + 
+                input.subSequence(Math.min(length-1, position), Math.min(length, position + 10)) + "'");
             while (position < length && Character.isWhitespace(currentChar())) {
                 ++position;
             }
@@ -63,6 +82,8 @@ public class Trie {
                 String word = input.subSequence(start, position).toString();
                 t = new WordTransition(word, start);
             }
+            System.out.println("New position: " + position);
+            System.out.println("Text in transition, '" + (t == null ? "null" : t.transitionToken()) + "'");
             return t;
         }
     }
@@ -74,10 +95,15 @@ public class Trie {
         @Override
         public Transition<Character> nextTransition() {
             CharacterTransition t = null;
+            System.out.println("CHARACTERTOKENIZER get next character transition");
+            System.out.println("Position: " + position);
+            System.out.println("Text under cursor, '" + input.subSequence(position, Math.min(length, position + 10)) + "'");
             if (position < length) {
                 t = new CharacterTransition(currentChar(), position);
                 position += 1;
             }
+            System.out.println("New position: " + position);
+            System.out.println("Text in transition, '" + (t == null ? "null" : t.transitionToken()) + "'");
             return t;
         }
     }
@@ -186,6 +212,11 @@ public class Trie {
             for (String emit : emits) {
                 int position = tn.getStart() + tn.getLength();
                 int start = position - emit.length();
+                if (start < 0) {
+                    System.out.println("START < 0 !! at " + position + " on '" + emit + "', length " + emit.length());
+                    System.out.println("TEXT is '" + text + "'");
+                    System.out.println(tn);
+                }
                 boolean isWholeWord = tknz.isWholeWord(start);
                 if (isWholeWord || !trieConfig.isOnlyWholeWords()) {
                     emitCandidateHolder.addCandidate(

--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -65,7 +65,6 @@ public class Trie {
                 t = new CharacterTransition(cur);
                 cur = ct.next();
             }
-            
             return t;
         }
     }
@@ -105,7 +104,7 @@ public class Trie {
         }
         
         public int position() {
-            return match.length();
+            return match.length() - 1;
         }
         
         public boolean isWholeWord(int start) {
@@ -113,7 +112,7 @@ public class Trie {
                 lookahead = kwt.nextTransition();
             }
             return ((start == 0 || 
-                     Character.isSpaceChar(match.codePointAt(start))) && 
+                     Character.isSpaceChar(match.codePointAt(start-1))) && 
                     (lookahead == null || lookahead.isWordSeparator()));
         }
     }
@@ -182,7 +181,7 @@ public class Trie {
             Collection<String> emits = currentState.emit();
             for (String emit : emits) {
                 int position = tknz.position();
-                int start = tknz.position() - emit.length() + 1;
+                int start = position - emit.length() + 1;
                 boolean isWholeWord = tknz.isWholeWord(start);
                 if (isWholeWord || !trieConfig.isOnlyWholeWords()) {
                     emitCandidateHolder.addCandidate(

--- a/src/main/java/org/ahocorasick/trie/TrieConfig.java
+++ b/src/main/java/org/ahocorasick/trie/TrieConfig.java
@@ -8,8 +8,6 @@ public class TrieConfig {
 
     private boolean caseInsensitive = false;
     
-    private boolean wordTransitions = false;
-
     public boolean isAllowOverlaps() {
         return allowOverlaps;
     }
@@ -32,13 +30,5 @@ public class TrieConfig {
 
     public void setCaseInsensitive(boolean caseInsensitive) {
         this.caseInsensitive = caseInsensitive;
-    }
-    
-    public boolean hasWordTransitions() {
-        return wordTransitions;
-    }
-    
-    public void setWordTransitions(boolean wordNodes) {
-        this.wordTransitions = wordNodes;
     }
 }

--- a/src/main/java/org/ahocorasick/trie/TrieConfig.java
+++ b/src/main/java/org/ahocorasick/trie/TrieConfig.java
@@ -8,7 +8,7 @@ public class TrieConfig {
 
     private boolean caseInsensitive = false;
     
-    private boolean wordNodes = false;
+    private boolean wordTransitions = false;
 
     public boolean isAllowOverlaps() {
         return allowOverlaps;
@@ -19,7 +19,7 @@ public class TrieConfig {
     }
 
     public boolean isOnlyWholeWords() {
-        return wordNodes || onlyWholeWords;
+        return onlyWholeWords;
     }
 
     public void setOnlyWholeWords(boolean onlyWholeWords) {
@@ -34,11 +34,11 @@ public class TrieConfig {
         this.caseInsensitive = caseInsensitive;
     }
     
-    public boolean hasOnlyWordNodes() {
-        return wordNodes;
+    public boolean hasWordTransitions() {
+        return wordTransitions;
     }
     
-    public void setOnlyWordNodes(boolean wordNodes) {
-        this.wordNodes = wordNodes;
+    public void setWordTransitions(boolean wordNodes) {
+        this.wordTransitions = wordNodes;
     }
 }

--- a/src/main/java/org/ahocorasick/trie/TrieConfig.java
+++ b/src/main/java/org/ahocorasick/trie/TrieConfig.java
@@ -7,6 +7,8 @@ public class TrieConfig {
     private boolean onlyWholeWords = false;
 
     private boolean caseInsensitive = false;
+    
+    private boolean wordNodes = false;
 
     public boolean isAllowOverlaps() {
         return allowOverlaps;
@@ -17,7 +19,7 @@ public class TrieConfig {
     }
 
     public boolean isOnlyWholeWords() {
-        return onlyWholeWords;
+        return wordNodes || onlyWholeWords;
     }
 
     public void setOnlyWholeWords(boolean onlyWholeWords) {
@@ -30,5 +32,13 @@ public class TrieConfig {
 
     public void setCaseInsensitive(boolean caseInsensitive) {
         this.caseInsensitive = caseInsensitive;
+    }
+    
+    public boolean hasOnlyWordNodes() {
+        return wordNodes;
+    }
+    
+    public void setOnlyWordNodes(boolean wordNodes) {
+        this.wordNodes = wordNodes;
     }
 }

--- a/src/main/java/org/ahocorasick/trie/WordTransition.java
+++ b/src/main/java/org/ahocorasick/trie/WordTransition.java
@@ -26,7 +26,7 @@ public class WordTransition extends Transition<String> {
     }
 
     @Override
-    public void updateMatch(StringBuffer match) {
+    public void updateMatch(StringBuilder match) {
         if (0 < match.length()) {
             match.append(' ');
         }

--- a/src/main/java/org/ahocorasick/trie/WordTransition.java
+++ b/src/main/java/org/ahocorasick/trie/WordTransition.java
@@ -21,21 +21,16 @@ package org.ahocorasick.trie;
  */
 public class WordTransition extends Transition<String> {
 
-    public WordTransition(String s) {
-        super(s);
+    public WordTransition(String s, int start) {
+        super(s, start, s.length());
     }
 
-    @Override
-    public void updateMatch(StringBuilder match) {
-        if (0 < match.length()) {
-            match.append(' ');
-        }
-        match.append(token);
+    public WordTransition(String s) {
+        this(s, 0);
     }
 
     @Override
     public boolean isWordSeparator() {
         return true;
     }
-    
 }

--- a/src/main/java/org/ahocorasick/trie/WordTransition.java
+++ b/src/main/java/org/ahocorasick/trie/WordTransition.java
@@ -28,9 +28,4 @@ public class WordTransition extends Transition<String> {
     public WordTransition(String s) {
         this(s, 0);
     }
-
-    @Override
-    public boolean isWordSeparator() {
-        return true;
-    }
 }

--- a/src/main/java/org/ahocorasick/trie/WordTransition.java
+++ b/src/main/java/org/ahocorasick/trie/WordTransition.java
@@ -16,19 +16,26 @@
 package org.ahocorasick.trie;
 
 /**
- * Enables the trie to model transitions on whole words or characters
- * ... or whatever!
+ * Model transitions on words
  * @author doug.lovell
- * @param <T>
  */
-public abstract class Transition<T> {
-    protected final T token;
-    public Transition(T token) {
-        this.token = token;
+public class WordTransition extends Transition<String> {
+
+    public WordTransition(String s) {
+        super(s);
     }
-    public T transitionToken() {
-        return token;
+
+    @Override
+    public void updateMatch(StringBuffer match) {
+        if (0 < match.length()) {
+            match.append(' ');
+        }
+        match.append(token);
     }
-    public abstract void updateMatch(StringBuffer match);
-    public abstract boolean isWordSeparator();
+
+    @Override
+    public boolean isWordSeparator() {
+        return true;
+    }
+    
 }

--- a/src/test/java/org/ahocorasick/trie/StateTest.java
+++ b/src/test/java/org/ahocorasick/trie/StateTest.java
@@ -1,6 +1,5 @@
 package org.ahocorasick.trie;
 
-import org.ahocorasick.trie.State;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
@@ -10,15 +9,18 @@ public class StateTest {
     @Test
     public void constructSequenceOfCharacters() {
         State rootState = new State();
+        Transition a = new CharacterTransition('a');
+        Transition b = new CharacterTransition('b');
+        Transition c = new CharacterTransition('c');
         rootState
-            .addState('a')
-            .addState('b')
-            .addState('c');
-        State currentState = rootState.nextState('a');
+            .addState(a)
+            .addState(b)
+            .addState(c);
+        State currentState = rootState.nextState(a);
         assertEquals(1, currentState.getDepth());
-        currentState = currentState.nextState('b');
+        currentState = currentState.nextState(b);
         assertEquals(2, currentState.getDepth());
-        currentState = currentState.nextState('c');
+        currentState = currentState.nextState(c);
         assertEquals(3, currentState.getDepth());
     }
 

--- a/src/test/java/org/ahocorasick/trie/StateTest.java
+++ b/src/test/java/org/ahocorasick/trie/StateTest.java
@@ -23,5 +23,23 @@ public class StateTest {
         currentState = currentState.nextState(c);
         assertEquals(3, currentState.getDepth());
     }
+    
+    @Test
+    public void constructSequenceOfWords() {
+        State rootState = new State();
+        Transition a = new WordTransition("Alpha");
+        Transition b = new WordTransition("Bravo");
+        Transition c = new WordTransition("Charlie");
+        rootState
+            .addState(a)
+            .addState(b)
+            .addState(c);
+        State currentState = rootState.nextState(a);
+        assertEquals(1, currentState.getDepth());
+        currentState = currentState.nextState(b);
+        assertEquals(2, currentState.getDepth());
+        currentState = currentState.nextState(c);
+        assertEquals(3, currentState.getDepth());
+    }
 
 }

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -10,8 +10,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 public class TrieTest {
 
@@ -393,6 +394,41 @@ public class TrieTest {
         assertToken(tokensIt.next(), " from the rear, ", false, false, false);
         assertToken(tokensIt.next(), "Gamma", true, true, false);
         assertToken(tokensIt.next(), " in reserve", false, false, false);
+    }
+
+    @Test
+    public void tokenizeFullSentenceByWords() {
+        Trie trie = Trie.builder()
+                .wordTransitions()
+                .addKeyword("Alpha")
+                .addKeyword("Beta")
+                .addKeyword("Gamma")
+                .build();
+        Collection<Token> tokens = trie.tokenize("Hear: Alpha team first, Beta from the rear, Gamma in reserve");
+        assertEquals(7, tokens.size());
+        Iterator<Token> tokensIt = tokens.iterator();
+        assertToken(tokensIt.next(), "Hear: ", false, false, false);
+        assertToken(tokensIt.next(), "Alpha", true, true, false);
+        assertToken(tokensIt.next(), " team first, ", false, false, false);
+        assertToken(tokensIt.next(), "Beta", true, true, false);
+        assertToken(tokensIt.next(), " from the rear, ", false, false, false);
+        assertToken(tokensIt.next(), "Gamma", true, true, false);
+        assertToken(tokensIt.next(), " in reserve", false, false, false);
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    
+    @Test
+    public void wordTransitionsThrowsExceptionAfterKeywordsAdded()
+      throws IllegalStateException {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Unable to switch to word transitions after keywords added");
+        Trie trie = Trie.builder()
+                .addKeyword("Happy for now")
+                .wordTransitions()
+                .addKeyword("Not so happy")
+                .build();
     }
 
     @Test

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -595,16 +595,17 @@ public class TrieTest {
     */
     @Test
     public void spacesAroundKeywordByWords() {
-        String keyword = "lorem ipso facto genera linden pharma six 1";
+        String text = "lorem ipso facto genera linden pharma six 1";
+        String keyword = " " + text + " ";
         Trie trie = Trie.builder()
                 .onlyWholeWords()
                 .caseInsensitive()
-                .addKeyword(" " + keyword + " ")
+                .addKeyword(keyword)
                 .build();
         Collection < Emit > emits = trie.parseText(
-                keyword + " under addressed object ");
+                text + " under addressed object ");
         assertEquals(1, emits.size());
-        checkEmit(emits.iterator().next(), 0, keyword.length() - 1, keyword);
+        checkEmit(emits.iterator().next(), 0, text.length() - 1, keyword);
     }
 
     private void assertToken(Token token, String fragment, boolean match, boolean wholeWord, boolean whiteSpace) {

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -562,6 +562,22 @@ public class TrieTest {
         checkEmit(firstMatch, 5, 8, "this");
     }
 
+   @Test
+    public void unicodeInKeyword() {
+        // The upper case character ('İ') is Unicode,
+        // which was read by AC as a 2-byte char
+        String target = "it is so much LİKE Unicode to mess with Java"; 
+        Trie trie = Trie.builder()
+                .onlyWholeWords()
+                .addKeyword("so much LİKE Unicode")
+                .addKeyword("it is")
+                .build();
+        Collection<Emit> emits = trie.parseText(target);
+        Iterator<Emit> it = emits.iterator();
+        checkEmit(it.next(), 0, 4, "it is");
+        checkEmit(it.next(), 6, 25, "so much LİKE Unicode");
+    }
+
     @Test
     public void partialMatchWhiteSpaces() {
         Trie trie = Trie.builder()
@@ -571,6 +587,41 @@ public class TrieTest {
         Collection < Emit > emits = trie.parseText("#sugar-123 #sugar-1234"); // left, middle, right test
         assertEquals(1, emits.size()); // Match must not be made
         checkEmit(emits.iterator().next(), 0, 9, "#sugar-123");
+    }
+
+    /* 
+    What does "onlyWholeWords" mean when the keyword itself has spaces?
+    @Test
+    public void spacesAroundKeyword() {
+        String keyword = " lorem ipso facto genera linden pharma six 1 ";
+        Trie trie = Trie.builder()
+                .onlyWholeWords()
+                .caseInsensitive()
+                .addKeyword(keyword)
+                .build();
+        Collection < Emit > emits = trie.parseText(
+                "gravita conundrum" + keyword + "under addressed object ");
+        assertEquals(1, emits.size());
+        checkEmit(emits.iterator().next(), 0, keyword.length() + 1, keyword);
+    }
+    */
+    
+    /*
+    For wordTransitions, we'll ignore leading and trailing white space
+    included on keywords
+    */
+    @Test
+    public void spacesAroundKeywordByWords() {
+        String keyword = "lorem ipso facto genera linden pharma six 1";
+        Trie trie = Trie.builder()
+                .wordTransitions()
+                .caseInsensitive()
+                .addKeyword(" " + keyword + " ")
+                .build();
+        Collection < Emit > emits = trie.parseText(
+                keyword + " under addressed object ");
+        assertEquals(1, emits.size());
+        checkEmit(emits.iterator().next(), 0, keyword.length(), keyword);
     }
 
     private void assertToken(Token token, String fragment, boolean match, boolean wholeWord, boolean whiteSpace) {

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -81,7 +81,7 @@ public class TrieTest {
     @Test
     public void variousKeywordsFirstMatchWordTransitions() {
         Trie trie = Trie.builder()
-                .wordTransitions()
+                .onlyWholeWords()
                 .addKeyword("abc")
                 .addKeyword("bcd")
                 .addKeyword("cde")
@@ -198,7 +198,7 @@ public class TrieTest {
 @Test
     public void recipesWordTransitions() {
         Trie trie = Trie.builder()
-                .wordTransitions()
+                .onlyWholeWords()
                 .addKeyword("veal")
                 .addKeyword("cauliflower")
                 .addKeyword("broccoli")
@@ -265,7 +265,7 @@ public class TrieTest {
     public void nonOverlappingWordTransitions() {
         Trie trie = Trie.builder()
                 .removeOverlaps()
-                .wordTransitions()
+                .onlyWholeWords()
                 .addKeyword("peper molen")
                 .addKeyword("molen wiel")
                 .addKeyword("wiel dop")
@@ -436,7 +436,7 @@ public class TrieTest {
     @Test
     public void tokenizeFullSentenceByWords() {
         Trie trie = Trie.builder()
-                .wordTransitions()
+                .onlyWholeWords()
                 .addKeyword("Alpha")
                 .addKeyword("Beta")
                 .addKeyword("Gamma")
@@ -457,13 +457,13 @@ public class TrieTest {
     public ExpectedException thrown = ExpectedException.none();
     
     @Test
-    public void wordTransitionsThrowsExceptionAfterKeywordsAdded()
+    public void onlyWholeWordsThrowsExceptionAfterKeywordsAdded()
       throws IllegalStateException {
         thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Unable to switch to word transitions after keywords added");
+        thrown.expectMessage("Unable to switch to only whole words after keywords added");
         Trie trie = Trie.builder()
                 .addKeyword("Happy for now")
-                .wordTransitions()
+                .onlyWholeWords()
                 .addKeyword("Not so happy")
                 .build();
     }
@@ -589,46 +589,27 @@ public class TrieTest {
         checkEmit(emits.iterator().next(), 0, 9, "#sugar-123");
     }
 
-    /* 
-    What does "onlyWholeWords" mean when the keyword itself has spaces?
-    @Test
-    public void spacesAroundKeyword() {
-        String keyword = " lorem ipso facto genera linden pharma six 1 ";
-        Trie trie = Trie.builder()
-                .onlyWholeWords()
-                .caseInsensitive()
-                .addKeyword(keyword)
-                .build();
-        Collection < Emit > emits = trie.parseText(
-                "gravita conundrum" + keyword + "under addressed object ");
-        assertEquals(1, emits.size());
-        checkEmit(emits.iterator().next(), 0, keyword.length() + 1, keyword);
-    }
-    */
-    
     /*
-    For wordTransitions, we'll ignore leading and trailing white space
+    For onlyWholeWords, we'll ignore leading and trailing white space
     included on keywords
     */
     @Test
     public void spacesAroundKeywordByWords() {
         String keyword = "lorem ipso facto genera linden pharma six 1";
         Trie trie = Trie.builder()
-                .wordTransitions()
+                .onlyWholeWords()
                 .caseInsensitive()
                 .addKeyword(" " + keyword + " ")
                 .build();
         Collection < Emit > emits = trie.parseText(
                 keyword + " under addressed object ");
         assertEquals(1, emits.size());
-        checkEmit(emits.iterator().next(), 0, keyword.length(), keyword);
+        checkEmit(emits.iterator().next(), 0, keyword.length() - 1, keyword);
     }
 
     private void assertToken(Token token, String fragment, boolean match, boolean wholeWord, boolean whiteSpace) {
         assertEquals(fragment, token.getFragment());
         assertEquals(match, token.isMatch());
-        assertEquals(wholeWord, token.isWholeWord());
-        assertEquals(whiteSpace, token.isWhiteSpace());
     }
 
     private void checkEmit(Emit next, int expectedStart, int expectedEnd, String expectedKeyword) {

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -79,8 +79,9 @@ public class TrieTest {
     }
 
     @Test
-    public void variousKeywordsFirstMatch() {
+    public void variousKeywordsFirstMatchWordTransitions() {
         Trie trie = Trie.builder()
+                .wordTransitions()
                 .addKeyword("abc")
                 .addKeyword("bcd")
                 .addKeyword("cde")
@@ -194,6 +195,23 @@ public class TrieTest {
         checkEmit(iterator.next(), 51, 58, "broccoli");
     }
 
+@Test
+    public void recipesWordTransitions() {
+        Trie trie = Trie.builder()
+                .wordTransitions()
+                .addKeyword("veal")
+                .addKeyword("cauliflower")
+                .addKeyword("broccoli")
+                .addKeyword("tomatoes")
+                .build();
+        Collection<Emit> emits = trie.parseText("2 cauliflower 3 tomatoes 4 slices of veal 100g broccoli");
+        Iterator<Emit> iterator = emits.iterator();
+        checkEmit(iterator.next(), 2, 12, "cauliflower");
+        checkEmit(iterator.next(), 16, 23, "tomatoes");
+        checkEmit(iterator.next(), 37, 40, "veal");
+        checkEmit(iterator.next(), 47, 54, "broccoli");
+    }
+    
     @Test
     public void recipesFirstMatch() {
         Trie trie = Trie.builder()
@@ -229,6 +247,25 @@ public class TrieTest {
         Trie trie = Trie.builder()
                 .removeOverlaps()
                 .onlyWholeWords()
+                .addKeyword("peper molen")
+                .addKeyword("molen wiel")
+                .addKeyword("wiel dop")
+                .addKeyword("dop")
+                .build();
+        Collection<Emit> emits = trie.parseText("peper molen wiel dop xwiel dop wiel dopx wiel dop");
+        assertEquals(4, emits.size());
+        Iterator<Emit> iterator = emits.iterator();
+        checkEmit(iterator.next(), 0, 10, "peper molen");
+        checkEmit(iterator.next(), 12, 19, "wiel dop");
+        checkEmit(iterator.next(), 27, 29, "dop");
+        checkEmit(iterator.next(), 41, 48, "wiel dop");
+    }
+
+    @Test
+    public void nonOverlappingWordTransitions() {
+        Trie trie = Trie.builder()
+                .removeOverlaps()
+                .wordTransitions()
                 .addKeyword("peper molen")
                 .addKeyword("molen wiel")
                 .addKeyword("wiel dop")


### PR DESCRIPTION
We had hoped to have fewer changes.  Apology this is so many.

We've reimplemented the onlyWholeWords mode by using whole word transitions and ignoring white space.

Word transition mode uses about half as much heap memory for the Trie structure, but is within 10ths of a second the same speed as the character-based transition mode.

The revised code contains two tokenizers that generate transitions.  The first generates character transitions and emulates the original behavior.  The second generates word transitions.

Unfortunately, we also needed to change the method for returning the matched ranges in the searched text.  The reason for the change is that, with word transitions, any amount of whitespace in the text will match a word boundary.  The key can have different whitespace content than the matched text.

All current tests and some added tests all pass.
