### PR TITLE
Extend isPartialMatch method in Trie

### DIFF
--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -146,12 +146,27 @@ public class Trie {
 		return null;
 	}
 
-	private boolean isPartialMatch(CharSequence searchText, Emit emit) {
-		return (emit.getStart() != 0 &&
-			Character.isAlphabetic(searchText.charAt(emit.getStart() - 1))) ||
-			(emit.getEnd() + 1 != searchText.length() &&
-			Character.isAlphabetic(searchText.charAt(emit.getEnd() + 1)));
-	}
+    private boolean isPartialMatch(CharSequence searchText, Emit emit) {
+        for (int i = emit.getStart() - 1; i >= 0; i--) {
+	    if (Character.isWhitespace(searchText.charAt(i))) {
+                break;
+            } 
+            if (Character.isLetterOrDigit(searchText.charAt(i))) {
+                return true;
+            }
+        }
+
+        for(int i = emit.getEnd() + 1; i <= searchText.length() - 1; i++){
+	    if (Character.isWhitespace(searchText.charAt(i))) {
+                break;
+            } 
+            if (Character.isLetterOrDigit(searchText.charAt(i))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
 	private void removePartialMatches(CharSequence searchText, List<Emit> collectedEmits) {
 		List<Emit> removeEmits = new ArrayList<>();

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -286,9 +286,9 @@ public class TrieTest {
                 .onlyWholeWords()
                 .addKeyword("sugar")
                 .build();
-        Collection<Emit> emits = trie.parseText("sugarcane sugarcane sugar canesugar"); // left, middle, right test
+        Collection<Emit> emits = trie.parseText("sugar-cane sugarcane sugar canesugar"); // left, middle, right test
         assertEquals(1, emits.size()); // Match must not be made
-        checkEmit(emits.iterator().next(), 20, 24, "sugar");
+        checkEmit(emits.iterator().next(), 21, 25, "sugar");
     }
 
     @Test
@@ -297,9 +297,9 @@ public class TrieTest {
                 .onlyWholeWords()
                 .addKeyword("sugar")
                 .build();
-        Emit firstMatch = trie.firstMatch("sugarcane sugarcane sugar canesugar"); // left, middle, right test
+        Emit firstMatch = trie.firstMatch("sugar-cane sugarcane sugar canesugar"); // left, middle, right test
 
-        checkEmit(firstMatch, 20, 24, "sugar");
+        checkEmit(firstMatch, 21, 25, "sugar");
     }
 
     @Test


### PR DESCRIPTION
Add checks for letters and digits beyond just one index to the left and
right of the emit.

Before, a match of "sugar" in "sugar-cane" would not be seen as a parital match since only the dash was checked.
