### PR TITLE
Make Trie Serializable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,18 @@
             <scope>test</scope>
         </dependency>
 
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -78,8 +90,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/ahocorasick/interval/Interval.java
+++ b/src/main/java/org/ahocorasick/interval/Interval.java
@@ -1,6 +1,9 @@
 package org.ahocorasick.interval;
 
-public class Interval implements Intervalable {
+import java.io.IOException;
+import java.io.Serializable;
+
+public class Interval implements Intervalable, Serializable {
 
     private int start;
     private int end;
@@ -10,21 +13,24 @@ public class Interval implements Intervalable {
         this.end = end;
     }
 
+    @Override
     public int getStart() {
         return this.start;
     }
 
+    @Override
     public int getEnd() {
         return this.end;
     }
 
+    @Override
     public int size() {
         return end - start + 1;
     }
 
     public boolean overlapsWith(Interval other) {
         return this.start <= other.getEnd() &&
-               this.end >= other.getStart();
+                this.end >= other.getStart();
     }
 
     public boolean overlapsWith(int point) {
@@ -36,9 +42,9 @@ public class Interval implements Intervalable {
         if (!(o instanceof Intervalable)) {
             return false;
         }
-        Intervalable other = (Intervalable)o;
+        Intervalable other = (Intervalable) o;
         return this.start == other.getStart() &&
-               this.end == other.getEnd();
+                this.end == other.getEnd();
     }
 
     @Override
@@ -51,7 +57,7 @@ public class Interval implements Intervalable {
         if (!(o instanceof Intervalable)) {
             return -1;
         }
-        Intervalable other = (Intervalable)o;
+        Intervalable other = (Intervalable) o;
         int comparison = this.start - other.getStart();
         return comparison != 0 ? comparison : this.end - other.getEnd();
     }
@@ -61,4 +67,15 @@ public class Interval implements Intervalable {
         return this.start + ":" + this.end;
     }
 
+    protected void writeObject(java.io.ObjectOutputStream stream)
+            throws IOException {
+        stream.writeInt(start);
+        stream.writeInt(end);
+    }
+
+    protected void readObject(java.io.ObjectInputStream stream)
+            throws IOException, ClassNotFoundException, IllegalAccessException, NoSuchFieldException {
+        this.start = stream.readInt();
+        this.end = stream.readInt();
+    }
 }

--- a/src/main/java/org/ahocorasick/interval/IntervalNode.java
+++ b/src/main/java/org/ahocorasick/interval/IntervalNode.java
@@ -3,6 +3,7 @@ package org.ahocorasick.interval;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class IntervalNode {
 
@@ -10,14 +11,14 @@ public class IntervalNode {
 
     private IntervalNode left = null;
     private IntervalNode right = null;
-    private int point;
-    private List<Intervalable> intervals = new ArrayList<Intervalable>();
+    private final int point;
+    private final List<Intervalable> intervals = new ArrayList<>();
 
     public IntervalNode(List<Intervalable> intervals) {
         this.point = determineMedian(intervals);
 
-        List<Intervalable> toLeft = new ArrayList<Intervalable>();
-        List<Intervalable> toRight = new ArrayList<Intervalable>();
+        List<Intervalable> toLeft = new ArrayList<>();
+        List<Intervalable> toRight = new ArrayList<>();
 
         for (Intervalable interval : intervals) {
             if (interval.getEnd() < this.point) {
@@ -37,7 +38,7 @@ public class IntervalNode {
         }
     }
 
-    public int determineMedian(List<Intervalable> intervals) {
+    private int determineMedian(List<Intervalable> intervals) {
         int start = -1;
         int end = -1;
         for (Intervalable interval : intervals) {
@@ -55,7 +56,7 @@ public class IntervalNode {
 
     public List<Intervalable> findOverlaps(Intervalable interval) {
 
-        List<Intervalable> overlaps = new ArrayList<Intervalable>();
+        List<Intervalable> overlaps = new ArrayList<>();
 
         if (this.point < interval.getStart()) { // Tends to the right
             addToOverlaps(interval, overlaps, findOverlappingRanges(this.right, interval));
@@ -72,25 +73,21 @@ public class IntervalNode {
         return overlaps;
     }
 
-    protected void addToOverlaps(Intervalable interval, List<Intervalable> overlaps, List<Intervalable> newOverlaps) {
-        for (Intervalable currentInterval : newOverlaps) {
-            if (!currentInterval.equals(interval)) {
-                overlaps.add(currentInterval);
-            }
-        }
+    private void addToOverlaps(Intervalable interval, List<Intervalable> overlaps, List<Intervalable> newOverlaps) {
+        overlaps.addAll(newOverlaps.stream().filter(currentInterval -> !currentInterval.equals(interval)).collect(Collectors.toList()));
     }
 
-    protected List<Intervalable> checkForOverlapsToTheLeft(Intervalable interval) {
+    private List<Intervalable> checkForOverlapsToTheLeft(Intervalable interval) {
         return checkForOverlaps(interval, Direction.LEFT);
     }
 
-    protected List<Intervalable> checkForOverlapsToTheRight(Intervalable interval) {
+    private List<Intervalable> checkForOverlapsToTheRight(Intervalable interval) {
         return checkForOverlaps(interval, Direction.RIGHT);
     }
 
-    protected List<Intervalable> checkForOverlaps(Intervalable interval, Direction direction) {
+    private List<Intervalable> checkForOverlaps(Intervalable interval, Direction direction) {
 
-        List<Intervalable> overlaps = new ArrayList<Intervalable>();
+        List<Intervalable> overlaps = new ArrayList<>();
         for (Intervalable currentInterval : this.intervals) {
             switch (direction) {
                 case LEFT :
@@ -109,7 +106,7 @@ public class IntervalNode {
     }
 
 
-    protected List<Intervalable> findOverlappingRanges(IntervalNode node, Intervalable interval) {
+    private List<Intervalable> findOverlappingRanges(IntervalNode node, Intervalable interval) {
         if (node != null) {
             return node.findOverlaps(interval);
         }

--- a/src/main/java/org/ahocorasick/interval/IntervalTree.java
+++ b/src/main/java/org/ahocorasick/interval/IntervalTree.java
@@ -18,7 +18,7 @@ public class IntervalTree {
         // Sort the intervals on size, then left-most position
         Collections.sort(intervals, new IntervalableComparatorBySize());
 
-        Set<Intervalable> removeIntervals = new TreeSet<Intervalable>();
+        Set<Intervalable> removeIntervals = new TreeSet<>();
 
         for (Intervalable interval : intervals) {
             // If the interval was already removed, ignore it
@@ -31,9 +31,7 @@ public class IntervalTree {
         }
 
         // Remove all intervals that were overlapping
-        for (Intervalable removeInterval : removeIntervals) {
-            intervals.remove(removeInterval);
-        }
+        removeIntervals.forEach(intervals::remove);
 
         // Sort the intervals, now on left-most position only
         Collections.sort(intervals, new IntervalableComparatorByPosition());

--- a/src/main/java/org/ahocorasick/interval/Intervalable.java
+++ b/src/main/java/org/ahocorasick/interval/Intervalable.java
@@ -2,8 +2,8 @@ package org.ahocorasick.interval;
 
 public interface Intervalable extends Comparable {
 
-    public int getStart();
-    public int getEnd();
-    public int size();
+    int getStart();
+    int getEnd();
+    int size();
 
 }

--- a/src/main/java/org/ahocorasick/trie/Emit.java
+++ b/src/main/java/org/ahocorasick/trie/Emit.java
@@ -3,7 +3,11 @@ package org.ahocorasick.trie;
 import org.ahocorasick.interval.Interval;
 import org.ahocorasick.interval.Intervalable;
 
-public class Emit extends Interval implements Intervalable {
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+
+public class Emit extends Interval implements Intervalable, Serializable {
 
     private final String keyword;
 
@@ -21,4 +25,19 @@ public class Emit extends Interval implements Intervalable {
         return super.toString() + "=" + this.keyword;
     }
 
+    @Override
+    protected void writeObject(java.io.ObjectOutputStream stream)
+            throws IOException {
+        super.writeObject(stream);
+        stream.writeUTF(keyword);
+    }
+
+    @Override
+    protected void readObject(java.io.ObjectInputStream stream)
+            throws IOException, ClassNotFoundException, IllegalAccessException, NoSuchFieldException {
+        Field f = this.getClass().getDeclaredField("keyword");
+        super.readObject(stream);
+        f.setAccessible(true);
+        f.set(this, stream.readUTF());
+    }
 }

--- a/src/main/java/org/ahocorasick/trie/MatchToken.java
+++ b/src/main/java/org/ahocorasick/trie/MatchToken.java
@@ -2,7 +2,7 @@ package org.ahocorasick.trie;
 
 public class MatchToken extends Token {
 
-    private Emit emit;
+    private final Emit emit;
 
     public MatchToken(String fragment, Emit emit) {
         super(fragment);

--- a/src/main/java/org/ahocorasick/trie/State.java
+++ b/src/main/java/org/ahocorasick/trie/State.java
@@ -1,53 +1,67 @@
 package org.ahocorasick.trie;
 
+import com.google.common.base.Objects;
+
+import java.io.*;
+import java.lang.reflect.Field;
 import java.util.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * <p>
- *     A state has various important tasks it must attend to:
+ * A state has various important tasks it must attend to:
  * </p>
- *
- * <ul>
- *     <li>success; when a character points to another state, it must return that state</li>
- *     <li>failure; when a character has no matching state, the algorithm must be able to fall back on a
- *         state with less depth</li>
- *     <li>emits; when this state is passed and keywords have been matched, the matches must be
- *         'emitted' so that they can be used later on.</li>
- * </ul>
- *
  * <p>
- *     The root state is special in the sense that it has no failure state; it cannot fail. If it 'fails'
- *     it will still parse the next character and start from the root node. This ensures that the algorithm
- *     always runs. All other states always have a fail state.
+ * <ul>
+ * <li>success; when a character points to another state, it must return that state</li>
+ * <li>failure; when a character has no matching state, the algorithm must be able to fall back on a
+ * state with less depth</li>
+ * <li>emits; when this state is passed and keywords have been matched, the matches must be
+ * 'emitted' so that they can be used later on.</li>
+ * </ul>
+ * <p>
+ * <p>
+ * The root state is special in the sense that it has no failure state; it cannot fail. If it 'fails'
+ * it will still parse the next character and start from the root node. This ensures that the algorithm
+ * always runs. All other states always have a fail state.
  * </p>
  *
  * @author Robert Bor
  */
-public class State {
+public class State implements Serializable {
 
-    /** effective the size of the keyword */
+    /**
+     * effective the size of the keyword
+     */
     private final int depth;
 
-    /** only used for the root state to refer to itself in case no matches have been found */
+    /**
+     * only used for the root state to refer to itself in case no matches have been found
+     */
     private final State rootState;
 
     /**
      * referred to in the white paper as the 'goto' structure. From a state it is possible to go
      * to other states, depending on the character passed.
      */
-    private Map<Character,State> success = new HashMap<Character, State>();
+    private Map<Character, State> success = new TreeMap<>();
 
-    /** if no matching states are found, the failure state will be returned */
+    /**
+     * if no matching states are found, the failure state will be returned
+     */
     private State failure = null;
 
-    /** whenever this state is reached, it will emit the matches keywords for future reference */
+    /**
+     * whenever this state is reached, it will emit the matches keywords for future reference
+     */
     private Set<String> emits = null;
 
     public State() {
         this(0);
     }
 
-    public State(int depth) {
+    private State(int depth) {
         this.depth = depth;
         this.rootState = depth == 0 ? this : null;
     }
@@ -64,14 +78,14 @@ public class State {
         return nextState(character, false);
     }
 
-    public State nextStateIgnoreRootState(Character character) {
+    private State nextStateIgnoreRootState(Character character) {
         return nextState(character, true);
     }
 
     public State addState(Character character) {
         State nextState = nextStateIgnoreRootState(character);
         if (nextState == null) {
-            nextState = new State(this.depth+1);
+            nextState = new State(this.depth + 1);
             this.success.put(character, nextState);
         }
         return nextState;
@@ -89,13 +103,11 @@ public class State {
     }
 
     public void addEmit(Collection<String> emits) {
-        for (String emit : emits) {
-            addEmit(emit);
-        }
+        emits.forEach(this::addEmit);
     }
 
     public Collection<String> emit() {
-        return this.emits == null ? Collections.<String> emptyList() : this.emits;
+        return this.emits == null ? Collections.emptyList() : this.emits;
     }
 
     public State failure() {
@@ -114,4 +126,156 @@ public class State {
         return this.success.keySet();
     }
 
+    private void writeObject(StateObjectOutputStream stream)
+            throws IOException {
+        stream.writeInt(this.depth);
+        stream.writeInt(this.success.size());
+        for (Map.Entry<Character, State> e : this.success.entrySet()) {
+            stream.writeObject(e.getKey());
+
+            Integer reference = stream.objectToReference.get(e.getValue());
+            if (reference == null) {
+                stream.objectToReference.put(e.getValue(), stream.incrementAndGetReferenceCount());
+                stream.writeInt(0);
+                stream.writeInt(stream.getReferenceCount());
+                stream.writeObject(e.getValue());
+            } else {
+                stream.writeInt(reference);
+            }
+        }
+        stream.writeObject(this.emits);
+    }
+
+    private void writeObject(ObjectOutputStream stream)
+            throws IOException {
+        if (stream instanceof StateObjectOutputStream) {
+            writeObject((StateObjectOutputStream) stream);
+        } else {
+            // this is the root state
+            IdentityHashMap<Object, Integer> objectToReference = new IdentityHashMap<>();
+            writeObject(new StateObjectOutputStream(stream, objectToReference, 1));
+        }
+    }
+
+    private void readObject(StateObjectInputStream stream)
+            throws IOException, ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+
+        // Use reflection to modify final field
+        Field f = this.getClass().getDeclaredField("depth");
+        f.setAccessible(true);
+        f.set(this, checkNotNull(stream.readInt()));
+
+        f = this.getClass().getDeclaredField("rootState");
+        f.setAccessible(true);
+        f.set(this, (depth == 0) ? this : null);
+        int successSize = checkNotNull(stream.readInt());
+        success = new TreeMap<>();
+        for (int i = 0; i < successSize; i++) {
+            Character character = checkNotNull((Character) stream.readObject());
+            Integer reference = checkNotNull(stream.readInt());
+            State treeState;
+            if (reference == 0) {
+                Integer referenceID = checkNotNull(stream.readInt());
+                treeState = checkNotNull((State) stream.readObject());
+                stream.getReferenceToObject().put(referenceID, treeState);
+            } else {
+                try {
+                    treeState = checkNotNull((State) stream.getReferenceToObject().get(reference));
+                } catch (NullPointerException e) {
+                    throw new RuntimeException("reference=" + reference + ", " + stream.getReferenceToObject().size(), e);
+                }
+            }
+            success.put(character, treeState);
+        }
+        emits = (TreeSet) stream.readObject();
+    }
+
+    private void readObject(ObjectInputStream stream)
+            throws IOException, ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+        if (stream instanceof StateObjectInputStream) {
+            readObject((StateObjectInputStream) stream);
+        } else {
+            // this is the root state
+            IdentityHashMap<Integer, Object> referenceToObject = new IdentityHashMap<>();
+            readObject(new StateObjectInputStream(stream, referenceToObject));
+            // failure was not serialized/deserialized as it complicates logic, let's just reconstruct it
+            Trie.constructFailureStates(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        State state = (State) other;
+        return equals(this, state, new IdentityHashMap<>());
+    }
+
+    private boolean equals(State self, State other, IdentityHashMap<State, Integer> equalityReferenceMap) {
+        if (self == other) return true;
+        return !(self == null || other == null) &&
+                self.depth == other.depth &&
+                ((self.depth > 0 && self.rootState == null && other.rootState == null) ||
+                 (self.depth == 0 && self == self.rootState && other == other.rootState)) &&
+                gotoEquality(self.success, other.success, equalityReferenceMap) &&
+                equals(self.failure, other.failure, equalityReferenceMap) && Objects.equal(self.emits, other.emits);
+    }
+
+    private boolean gotoEquality(Map<Character, State> mine, Map<Character, State> other,
+                                 IdentityHashMap<State, Integer> equalityReferenceMap) {
+        if (mine.size() != other.size()) return false;
+        Iterator otherEntrySet = other.entrySet().iterator();
+        for (Map.Entry<Character, State> e : mine.entrySet()) {
+            Map.Entry<Character, State> otherE = (Map.Entry<Character, State>) otherEntrySet.next();
+
+            if (!e.getKey().equals(otherE.getKey())) return false;
+            Integer reference = equalityReferenceMap.get(e.getValue());
+            if (reference == null) {
+                equalityReferenceMap.put(e.getValue(), equalityReferenceMap.size() + 1);
+                if (!equals(e.getValue(), otherE.getValue(), equalityReferenceMap)) return false;
+            }
+        }
+        return true;
+    }
+
+    private class StateObjectOutputStream extends ObjectOutputStream {
+
+        private final IdentityHashMap<Object, Integer> objectToReference;
+        private int referenceCount;
+
+        StateObjectOutputStream(ObjectOutputStream out, IdentityHashMap<Object, Integer> objectToReference,
+                                int referenceCount)
+                throws IOException {
+            super(out);
+            this.objectToReference = objectToReference;
+            this.referenceCount = referenceCount;
+        }
+
+        IdentityHashMap<Object, Integer> getObjectToReference() {
+            return objectToReference;
+        }
+
+        int getReferenceCount() {
+            return referenceCount;
+        }
+
+        int incrementAndGetReferenceCount() {
+            referenceCount += 1;
+            return referenceCount;
+        }
+    }
+
+    class StateObjectInputStream extends ObjectInputStream {
+        private final IdentityHashMap<Integer, Object> referenceToObject;
+
+        StateObjectInputStream(ObjectInputStream in, IdentityHashMap<Integer, Object> referenceToObject)
+                throws IOException {
+            super(in);
+            this.referenceToObject = referenceToObject;
+        }
+
+        IdentityHashMap<Integer, Object> getReferenceToObject() {
+            return referenceToObject;
+        }
+    }
 }

--- a/src/main/java/org/ahocorasick/trie/Token.java
+++ b/src/main/java/org/ahocorasick/trie/Token.java
@@ -2,7 +2,7 @@ package org.ahocorasick.trie;
 
 public abstract class Token {
 
-    private String fragment;
+    private final String fragment;
 
     public Token(String fragment) {
         this.fragment = fragment;

--- a/src/main/java/org/ahocorasick/trie/TrieConfig.java
+++ b/src/main/java/org/ahocorasick/trie/TrieConfig.java
@@ -1,6 +1,9 @@
 package org.ahocorasick.trie;
 
-public class TrieConfig {
+import java.io.IOException;
+import java.io.Serializable;
+
+public class TrieConfig implements Serializable {
 
     private boolean allowOverlaps = true;
 
@@ -12,9 +15,13 @@ public class TrieConfig {
 
     private boolean stopOnHit = false;
 
-    public boolean isStopOnHit() { return stopOnHit; }
+    public boolean isStopOnHit() {
+        return stopOnHit;
+    }
 
-    public void setStopOnHit(boolean stopOnHit) { this.stopOnHit = stopOnHit; }
+    public void setStopOnHit(boolean stopOnHit) {
+        this.stopOnHit = stopOnHit;
+    }
 
     public boolean isAllowOverlaps() {
         return allowOverlaps;
@@ -32,7 +39,9 @@ public class TrieConfig {
         this.onlyWholeWords = onlyWholeWords;
     }
 
-    public boolean isOnlyWholeWordsWhiteSpaceSeparated() { return onlyWholeWordsWhiteSpaceSeparated; }
+    public boolean isOnlyWholeWordsWhiteSpaceSeparated() {
+        return onlyWholeWordsWhiteSpaceSeparated;
+    }
 
     public void setOnlyWholeWordsWhiteSpaceSeparated(boolean onlyWholeWordsWhiteSpaceSeparated) {
         this.onlyWholeWordsWhiteSpaceSeparated = onlyWholeWordsWhiteSpaceSeparated;
@@ -44,5 +53,35 @@ public class TrieConfig {
 
     public void setCaseInsensitive(boolean caseInsensitive) {
         this.caseInsensitive = caseInsensitive;
+    }
+
+    private void writeObject(java.io.ObjectOutputStream stream)
+            throws IOException {
+        stream.writeBoolean(allowOverlaps);
+        stream.writeBoolean(onlyWholeWords);
+        stream.writeBoolean(onlyWholeWordsWhiteSpaceSeparated);
+        stream.writeBoolean(caseInsensitive);
+        stream.writeBoolean(stopOnHit);
+    }
+
+    private void readObject(java.io.ObjectInputStream stream)
+            throws IOException, ClassNotFoundException {
+        this.allowOverlaps = stream.readBoolean();
+        this.onlyWholeWords = stream.readBoolean();
+        onlyWholeWordsWhiteSpaceSeparated = stream.readBoolean();
+        this.caseInsensitive = stream.readBoolean();
+        this.stopOnHit = stream.readBoolean();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TrieConfig that = (TrieConfig) o;
+        return allowOverlaps == that.allowOverlaps &&
+                onlyWholeWords == that.onlyWholeWords &&
+                onlyWholeWordsWhiteSpaceSeparated == that.onlyWholeWordsWhiteSpaceSeparated &&
+                caseInsensitive == that.caseInsensitive &&
+                stopOnHit == that.stopOnHit;
     }
 }

--- a/src/main/java/org/ahocorasick/trie/handler/DefaultEmitHandler.java
+++ b/src/main/java/org/ahocorasick/trie/handler/DefaultEmitHandler.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class DefaultEmitHandler implements EmitHandler {
 
-    private List<Emit> emits = new ArrayList<>();
+    private final List<Emit> emits = new ArrayList<>();
 
     @Override
     public void emit(Emit emit) {

--- a/src/test/java/org/ahocorasick/interval/IntervalTest.java
+++ b/src/test/java/org/ahocorasick/interval/IntervalTest.java
@@ -2,11 +2,11 @@ package org.ahocorasick.interval;
 
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.*;
 
 public class IntervalTest {
 
@@ -44,7 +44,7 @@ public class IntervalTest {
 
     @Test
     public void comparable() {
-        Set<Interval> intervals = new TreeSet<Interval>();
+        Set<Interval> intervals = new TreeSet<>();
         intervals.add(new Interval(4, 6));
         intervals.add(new Interval(2, 7));
         intervals.add(new Interval(3, 4));

--- a/src/test/java/org/ahocorasick/interval/IntervalTreeTest.java
+++ b/src/test/java/org/ahocorasick/interval/IntervalTreeTest.java
@@ -12,7 +12,7 @@ public class IntervalTreeTest {
     
     @Test
     public void findOverlaps() {
-        List<Intervalable> intervals = new ArrayList<Intervalable>();
+        List<Intervalable> intervals = new ArrayList<>();
         intervals.add(new Interval(0, 2));
         intervals.add(new Interval(1, 3));
         intervals.add(new Interval(2, 4));
@@ -30,7 +30,7 @@ public class IntervalTreeTest {
 
     @Test
     public void removeOverlaps() {
-        List<Intervalable> intervals = new ArrayList<Intervalable>();
+        List<Intervalable> intervals = new ArrayList<>();
         intervals.add(new Interval(0, 2));
         intervals.add(new Interval(4, 5));
         intervals.add(new Interval(2, 10));
@@ -43,7 +43,7 @@ public class IntervalTreeTest {
 
     }
 
-    protected void assertOverlap(Intervalable interval, int expectedStart, int expectedEnd) {
+    private void assertOverlap(Intervalable interval, int expectedStart, int expectedEnd) {
         assertEquals(expectedStart, interval.getStart());
         assertEquals(expectedEnd, interval.getEnd());
     }

--- a/src/test/java/org/ahocorasick/interval/IntervalableComparatorByPositionTest.java
+++ b/src/test/java/org/ahocorasick/interval/IntervalableComparatorByPositionTest.java
@@ -12,7 +12,7 @@ public class IntervalableComparatorByPositionTest {
 
     @Test
     public void sortOnPosition() {
-        List<Intervalable> intervals = new ArrayList<Intervalable>();
+        List<Intervalable> intervals = new ArrayList<>();
         intervals.add(new Interval(4,5));
         intervals.add(new Interval(1,4));
         intervals.add(new Interval(3,8));

--- a/src/test/java/org/ahocorasick/interval/IntervalableComparatorBySizeTest.java
+++ b/src/test/java/org/ahocorasick/interval/IntervalableComparatorBySizeTest.java
@@ -12,7 +12,7 @@ public class IntervalableComparatorBySizeTest {
 
     @Test
     public void sortOnSize() {
-        List<Intervalable> intervals = new ArrayList<Intervalable>();
+        List<Intervalable> intervals = new ArrayList<>();
         intervals.add(new Interval(4,5));
         intervals.add(new Interval(1,4));
         intervals.add(new Interval(3,8));
@@ -24,7 +24,7 @@ public class IntervalableComparatorBySizeTest {
 
     @Test
     public void sortOnSizeThenPosition() {
-        List<Intervalable> intervals = new ArrayList<Intervalable>();
+        List<Intervalable> intervals = new ArrayList<>();
         intervals.add(new Interval(4,7));
         intervals.add(new Interval(2,5));
         Collections.sort(intervals, new IntervalableComparatorBySize());

--- a/src/test/java/org/ahocorasick/trie/StateTest.java
+++ b/src/test/java/org/ahocorasick/trie/StateTest.java
@@ -1,7 +1,9 @@
 package org.ahocorasick.trie;
 
-import org.ahocorasick.trie.State;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
+
+import java.io.Serializable;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -11,9 +13,9 @@ public class StateTest {
     public void constructSequenceOfCharacters() {
         State rootState = new State();
         rootState
-            .addState('a')
-            .addState('b')
-            .addState('c');
+                .addState('a')
+                .addState('b')
+                .addState('c');
         State currentState = rootState.nextState('a');
         assertEquals(1, currentState.getDepth());
         currentState = currentState.nextState('b');
@@ -22,4 +24,15 @@ public class StateTest {
         assertEquals(3, currentState.getDepth());
     }
 
+    @Test
+    public void testSerialization() {
+        State rootState = new State();
+        rootState.addState('a')
+                 .addState('b')
+                 .addState('c');
+        Trie.constructFailureStates(rootState);
+
+        Serializable copy = SerializationUtils.clone(rootState);
+        assertEquals(copy, rootState);
+    }
 }

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -1,6 +1,7 @@
 package org.ahocorasick.trie;
 
 import org.ahocorasick.trie.handler.EmitHandler;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ public class TrieTest {
         Collection<Emit> emits = trie.parseText("abc");
         Iterator<Emit> iterator = emits.iterator();
         checkEmit(iterator.next(), 0, 2, "abc");
+        checkSerialization(trie);
     }
 
     @Test
@@ -30,6 +32,7 @@ public class TrieTest {
                 .build();
         Emit firstMatch = trie.firstMatch("abc");
         checkEmit(firstMatch, 0, 2, "abc");
+        checkSerialization(trie);
     }
 
     @Test
@@ -40,6 +43,7 @@ public class TrieTest {
         Collection<Emit> emits = trie.parseText(" abc");
         Iterator<Emit> iterator = emits.iterator();
         checkEmit(iterator.next(), 1, 3, "abc");
+        checkSerialization(trie);
     }
 
     @Test
@@ -61,6 +65,7 @@ public class TrieTest {
         Collection<Emit> emits = trie.parseText("bcd");
         Iterator<Emit> iterator = emits.iterator();
         checkEmit(iterator.next(), 0, 2, "bcd");
+        checkSerialization(trie);
     }
 
     @Test
@@ -72,6 +77,7 @@ public class TrieTest {
                 .build();
         Emit firstMatch = trie.firstMatch("bcd");
         checkEmit(firstMatch, 0, 2, "bcd");
+        checkSerialization(trie);
     }
 
     @Test
@@ -88,6 +94,7 @@ public class TrieTest {
         Iterator<Emit> iterator = emits.iterator();
         checkEmit(iterator.next(), 2, 3, "he");
         checkEmit(iterator.next(), 1, 3, "she");
+        checkSerialization(trie);
     }
 
     @Test
@@ -104,6 +111,7 @@ public class TrieTest {
         checkEmit(iterator.next(), 2, 3, "he");
         checkEmit(iterator.next(), 1, 3, "she");
         checkEmit(iterator.next(), 2, 5, "hers");
+        checkSerialization(trie);
     }
 
     @Test
@@ -121,6 +129,7 @@ public class TrieTest {
         checkEmit(iterator.next(), 2, 3, "he");
         checkEmit(iterator.next(), 1, 3, "she");
         checkEmit(iterator.next(), 2, 5, "hers");
+        checkSerialization(trie);
     }
 
     @Test
@@ -133,6 +142,7 @@ public class TrieTest {
                 .build();
         Emit firstMatch = trie.firstMatch("ushers");
         checkEmit(firstMatch, 2, 3, "he");
+        checkSerialization(trie);
     }
 
     @Test
@@ -143,15 +153,9 @@ public class TrieTest {
                 .addKeyword("she")
                 .addKeyword("he")
                 .build();
-
+        checkSerialization(trie);
         final List<Emit> emits = new ArrayList<>();
-        EmitHandler emitHandler = new EmitHandler() {
-
-            @Override
-            public void emit(Emit emit) {
-                emits.add(emit);
-            }
-        };
+        EmitHandler emitHandler = emits::add;
         trie.parseText("ushers", emitHandler);
         assertEquals(3, emits.size()); // she @ 3, he @ 3, hers @ 5
         Iterator<Emit> iterator = emits.iterator();
@@ -168,6 +172,7 @@ public class TrieTest {
         Collection<Emit> emits = trie.parseText("h he her hers");
         Iterator<Emit> iterator = emits.iterator();
         checkEmit(iterator.next(), 9, 12, "hers");
+        checkSerialization(trie);
     }
 
     @Test
@@ -177,6 +182,7 @@ public class TrieTest {
                 .build();
         Emit firstMatch = trie.firstMatch("h he her hers");
         checkEmit(firstMatch, 9, 12, "hers");
+        checkSerialization(trie);
     }
 
     @Test
@@ -193,6 +199,7 @@ public class TrieTest {
         checkEmit(iterator.next(), 18, 25, "tomatoes");
         checkEmit(iterator.next(), 40, 43, "veal");
         checkEmit(iterator.next(), 51, 58, "broccoli");
+        checkSerialization(trie);
     }
 
     @Test
@@ -206,6 +213,7 @@ public class TrieTest {
         Emit firstMatch = trie.firstMatch("2 cauliflowers, 3 tomatoes, 4 slices of veal, 100g broccoli");
 
         checkEmit(firstMatch, 2, 12, "cauliflower");
+        checkSerialization(trie);
     }
 
     @Test
@@ -223,6 +231,7 @@ public class TrieTest {
         checkEmit(iterator.next(), 0, 7, "hehehehe");
         checkEmit(iterator.next(), 8, 9, "he");
         checkEmit(iterator.next(), 2, 9, "hehehehe");
+        checkSerialization(trie);
     }
 
     @Test
@@ -238,6 +247,7 @@ public class TrieTest {
         // With overlaps: ab@1, ab@3, ababc@4, cba@6, ab@7
         checkEmit(iterator.next(), 0, 4, "ababc");
         checkEmit(iterator.next(), 6, 7, "ab");
+        checkSerialization(trie);
     }
 
     @Test
@@ -250,6 +260,7 @@ public class TrieTest {
         Emit firstMatch = trie.firstMatch("ababcbab");
 
         checkEmit(firstMatch, 0, 4, "ababc");
+        checkSerialization(trie);
     }
 
     @Test
@@ -260,6 +271,7 @@ public class TrieTest {
                 .addKeyword("ababc")
                 .build();
         assertTrue(trie.containsMatch("ababcbab"));
+        checkSerialization(trie);
     }
 
     @Test
@@ -278,6 +290,7 @@ public class TrieTest {
                 .build();
         Collection<Emit> emits = trie.parseText("Turning");
         assertEquals(2, emits.size());
+        checkSerialization(trie);
     }
 
     @Test
@@ -289,6 +302,7 @@ public class TrieTest {
         Collection<Emit> emits = trie.parseText("sugarcane sugarcane sugar canesugar"); // left, middle, right test
         assertEquals(1, emits.size()); // Match must not be made
         checkEmit(emits.iterator().next(), 20, 24, "sugar");
+        checkSerialization(trie);
     }
 
     @Test
@@ -300,6 +314,7 @@ public class TrieTest {
         Emit firstMatch = trie.firstMatch("sugarcane sugarcane sugar canesugar"); // left, middle, right test
 
         checkEmit(firstMatch, 20, 24, "sugar");
+        checkSerialization(trie);
     }
 
     @Test
@@ -319,6 +334,7 @@ public class TrieTest {
         assertEquals(" from the rear, ", tokensIt.next().getFragment());
         assertEquals("Gamma", tokensIt.next().getFragment());
         assertEquals(" in reserve", tokensIt.next().getFragment());
+        checkSerialization(trie);
     }
 
     @Test
@@ -336,6 +352,7 @@ public class TrieTest {
         checkEmit(it.next(), 8, 11, "once");
         checkEmit(it.next(), 13, 17, "again");
         checkEmit(it.next(), 19, 23, "börkü");
+        checkSerialization(trie);
     }
 
     @Test
@@ -353,6 +370,7 @@ public class TrieTest {
         checkEmit(it.next(), 8, 11, "once");
         checkEmit(it.next(), 13, 17, "again");
         checkEmit(it.next(), 19, 23, "börkü");
+        checkSerialization(trie);
     }
 
     @Test
@@ -366,6 +384,7 @@ public class TrieTest {
         Emit firstMatch = trie.firstMatch("TurninG OnCe AgAiN BÖRKÜ");
 
         checkEmit(firstMatch, 0, 6, "turning");
+        checkSerialization(trie);
     }
 
     @Test
@@ -377,6 +396,7 @@ public class TrieTest {
                 .build();
         Collection<Token> tokens = trie.tokenize("Alpha Beta Gamma");
         assertEquals(5, tokens.size());
+        checkSerialization(trie);
     }
 
     // Test offered by XCurry, https://github.com/robert-bor/aho-corasick/issues/7
@@ -386,6 +406,7 @@ public class TrieTest {
                 .addKeyword("")
                 .build();
         trie.tokenize("Try a natural lip and subtle bronzer to keep all the focus on those big bright eyes with NARS Eyeshadow Duo in Rated R And the winner is... Boots No7 Advanced Renewal Anti-ageing Glycolic Peel Kit ($25 amazon.com) won most-appealing peel.");
+        checkSerialization(trie);
     }
 
     // Test offered by dwyerk, https://github.com/robert-bor/aho-corasick/issues/8
@@ -400,6 +421,7 @@ public class TrieTest {
         assertEquals(1, emits.size());
         Iterator<Emit> it = emits.iterator();
         checkEmit(it.next(), 5, 8, "this");
+        checkSerialization(trie);
     }
 
     @Test
@@ -413,6 +435,7 @@ public class TrieTest {
         assertEquals("THIS", target.substring(5, 9)); // Java does it the right way
         Emit firstMatch = trie.firstMatch(target);
         checkEmit(firstMatch, 5, 8, "this");
+        checkSerialization(trie);
     }
 
     @Test
@@ -421,9 +444,10 @@ public class TrieTest {
                 .onlyWholeWordsWhiteSpaceSeparated()
                 .addKeyword("#sugar-123")
                 .build();
-        Collection < Emit > emits = trie.parseText("#sugar-123 #sugar-1234"); // left, middle, right test
+        Collection<Emit> emits = trie.parseText("#sugar-123 #sugar-1234"); // left, middle, right test
         assertEquals(1, emits.size()); // Match must not be made
         checkEmit(emits.iterator().next(), 0, 9, "#sugar-123");
+        checkSerialization(trie);
     }
 
     private void checkEmit(Emit next, int expectedStart, int expectedEnd, String expectedKeyword) {
@@ -432,4 +456,8 @@ public class TrieTest {
         assertEquals(expectedKeyword, next.getKeyword());
     }
 
+    private void checkSerialization(Trie trie) {
+        Trie clonedTrie = SerializationUtils.clone(trie);
+        assertEquals(trie, clonedTrie);
+    }
 }


### PR DESCRIPTION
Wanting to use ahocorasick in a [Spark UDF](http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.functions) requires the code used in the UDF to be serializable.

Having found an older code that makes the Trie serializable in this [pull request](https://github.com/robert-bor/aho-corasick/pull/11), I started from it but modified it a bit. The biggest change from that code is the omission of using static fields.
