### PR TITLE
Allow to ack emits

### DIFF
--- a/src/main/java/org/ahocorasick/trie/Trie.java
+++ b/src/main/java/org/ahocorasick/trie/Trie.java
@@ -4,6 +4,7 @@ import org.ahocorasick.interval.IntervalTree;
 import org.ahocorasick.interval.Intervalable;
 import org.ahocorasick.trie.handler.DefaultEmitHandler;
 import org.ahocorasick.trie.handler.EmitHandler;
+import org.ahocorasick.trie.handler.StatefulEmitHandler;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -103,10 +104,13 @@ public class Trie {
         return new MatchToken(text.substring(emit.getStart(), emit.getEnd() + 1), emit);
     }
 
-    @SuppressWarnings("unchecked")
     public Collection<Emit> parseText(final CharSequence text) {
-        final DefaultEmitHandler emitHandler = new DefaultEmitHandler();
-        parseText(text, emitHandler);
+        return parseText(text, new DefaultEmitHandler());
+    }
+
+    @SuppressWarnings("unchecked")
+    public Collection<Emit> parseText(final CharSequence text, final StatefulEmitHandler emitHandler) {
+        parseText(text, (EmitHandler) emitHandler);
 
         final List<Emit> collectedEmits = emitHandler.getEmits();
 
@@ -281,8 +285,8 @@ public class Trie {
         // TODO: The check for empty might be superfluous.
         if (emits != null && !emits.isEmpty()) {
             for (final String emit : emits) {
-                emitHandler.emit(new Emit(position - emit.length() + 1, position, emit));
-                emitted = true;
+                emitted = emitHandler.emit(new Emit(position - emit.length() + 1, position, emit)) || emitted;
+                if(emitted && trieConfig.isStopOnHit()) break;
             }
         }
 

--- a/src/main/java/org/ahocorasick/trie/handler/DefaultEmitHandler.java
+++ b/src/main/java/org/ahocorasick/trie/handler/DefaultEmitHandler.java
@@ -5,15 +5,17 @@ import org.ahocorasick.trie.Emit;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DefaultEmitHandler implements EmitHandler {
+public class DefaultEmitHandler implements StatefulEmitHandler {
 
     private final List<Emit> emits = new ArrayList<>();
 
     @Override
-    public void emit(final Emit emit) {
+    public boolean emit(final Emit emit) {
         this.emits.add(emit);
+        return true;
     }
 
+    @Override
     public List<Emit> getEmits() {
         return this.emits;
     }

--- a/src/main/java/org/ahocorasick/trie/handler/EmitHandler.java
+++ b/src/main/java/org/ahocorasick/trie/handler/EmitHandler.java
@@ -3,5 +3,5 @@ package org.ahocorasick.trie.handler;
 import org.ahocorasick.trie.Emit;
 
 public interface EmitHandler {
-    void emit(Emit emit);
+    boolean emit(Emit emit);
 }

--- a/src/main/java/org/ahocorasick/trie/handler/StatefulEmitHandler.java
+++ b/src/main/java/org/ahocorasick/trie/handler/StatefulEmitHandler.java
@@ -1,0 +1,9 @@
+package org.ahocorasick.trie.handler;
+
+import java.util.List;
+
+import org.ahocorasick.trie.Emit;
+
+public interface StatefulEmitHandler extends EmitHandler {
+    List<Emit> getEmits();
+}


### PR DESCRIPTION
As specified in #53, one can now ack emits. Default emit handler automatically acks all emits.

I also allowed the use of `isOnlyWholeWords`, `isOnlyWholeWordsWhiteSpaceSeparated`
and `isAllowOverlaps` with a new interface `StatefulEmitHandler` as those were only being applied when using the `DefaultEmitHandler`