### PR TITLE
Fix unicode issue which caused wrong emit start/end

### DIFF
--- a/src/main/java/org/ahocorasick/trie/PayloadState.java
+++ b/src/main/java/org/ahocorasick/trie/PayloadState.java
@@ -81,20 +81,10 @@ public class PayloadState<T> {
         return nextState(character, true);
     }
 
-    public PayloadState<T> addState(String keyword) {
-        PayloadState<T> state = this;
-
-        for (final Character character : keyword.toCharArray()) {
-            state = state.addState(character);
-        }
-
-        return state;
-    }
-
     public PayloadState<T> addState(Character character) {
         PayloadState<T> nextState = nextStateIgnoreRootState(character);
         if (nextState == null) {
-            nextState = new PayloadState<T>(this.depth + 1);
+            nextState = new PayloadState<>(this.depth + 1);
             this.success.put(character, nextState);
         }
         return nextState;

--- a/src/main/java/org/ahocorasick/trie/PayloadTrie.java
+++ b/src/main/java/org/ahocorasick/trie/PayloadTrie.java
@@ -51,10 +51,6 @@ public class PayloadTrie<T> {
             return;
         }
 
-        if (isCaseInsensitive()) {
-            keyword = keyword.toLowerCase();
-        }
-
         addState(keyword).addEmit(new Payload<>(keyword, emit));
     }
 
@@ -69,15 +65,16 @@ public class PayloadTrie<T> {
             return;
         }
 
-        if (isCaseInsensitive()) {
-            keyword = keyword.toLowerCase();
-        }
-
         addState(keyword).addEmit(new Payload<>(keyword, null));
     }
 
     private PayloadState<T> addState(final String keyword) {
-        return getRootState().addState(keyword);
+        PayloadState<T> state = getRootState();
+        for (final Character character : keyword.toCharArray()) {
+            Character adjustedChar = isCaseInsensitive() ? Character.toLowerCase(character) : character;
+            state = state.addState(adjustedChar);
+        }
+        return state;
     }
 
     /**

--- a/src/test/java/org/ahocorasick/trie/PayloadTrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/PayloadTrieTest.java
@@ -197,9 +197,9 @@ public class PayloadTrieTest {
         Collection<PayloadEmit<String>> emits = trie.parseText("ushers");
         assertEquals(3, emits.size()); // she @ 3, he @ 3, hers @ 5
         Iterator<PayloadEmit<String>> iterator = emits.iterator();
-        checkEmit(iterator.next(), 2, 3, "he", "he");
-        checkEmit(iterator.next(), 1, 3, "she", "she");
-        checkEmit(iterator.next(), 2, 5, "hers", "hers");
+        checkEmit(iterator.next(), 2, 3, "HE", "he");
+        checkEmit(iterator.next(), 1, 3, "SHE", "she");
+        checkEmit(iterator.next(), 2, 5, "HERS", "hers");
     }
 
     @Test

--- a/src/test/java/org/ahocorasick/trie/TrieTest.java
+++ b/src/test/java/org/ahocorasick/trie/TrieTest.java
@@ -3,10 +3,7 @@ package org.ahocorasick.trie;
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -160,9 +157,9 @@ public class TrieTest {
         Collection<Emit> emits = trie.parseText("ushers");
         assertEquals(3, emits.size()); // she @ 3, he @ 3, hers @ 5
         Iterator<Emit> iterator = emits.iterator();
-        checkEmit(iterator.next(), 2, 3, "he");
-        checkEmit(iterator.next(), 1, 3, "she");
-        checkEmit(iterator.next(), 2, 5, "hers");
+        checkEmit(iterator.next(), 2, 3, "HE");
+        checkEmit(iterator.next(), 1, 3, "SHE");
+        checkEmit(iterator.next(), 2, 5, "HERS");
     }
 
     @Test
@@ -463,6 +460,23 @@ public class TrieTest {
         final Collection<Emit> emits = trie.parseText(text);
 
         assertEquals(textSize / interval, emits.size());
+    }
+
+    @Test
+    public void unicodeIssueBug39ReportedByHumanzz(){
+        // Problem: "İ".length => 1, "İ".toLowerCase().length => 2. This causes all sorts of unexpected behaviors
+        // and bugs where the Emit will have a size different from the original string.
+        // Soln: As in issue #8, convert at character level Character.toLowerCase('İ') => 'i'  + make sure
+        // that emit gets the properly cased keyword.
+        String upperLengthOne = "İnt";
+        Trie trie = Trie.builder()
+                .ignoreCase()
+                .onlyWholeWords()
+                .addKeyword(upperLengthOne)
+                .build();
+        Collection<Emit> emits = trie.parseText("İnt is good");
+        assertEquals(1, emits.size());
+        checkEmit(emits.iterator().next(), 0, 2, upperLengthOne);
     }
 
     @Test(timeout=30_000)


### PR DESCRIPTION
Fix builds upon fix of https://github.com/robert-bor/aho-corasick/pull/82

Initially I tried to rebase the original fix, but after applying it and doing some benchmarks I found out that doing lower case for the whole string has some performance penalty (around -10% in my measurements). for large texts it would be probably worse.

I spent some time with this issue, it's not trivial to fix it 100% for all unicode chars without impacting performance negatively. 

The proposed fix simply align lower case conversion code in the [building phase](https://github.com/robert-bor/aho-corasick/compare/master...omarshibli:issue82?expand=1#diff-191e22d27f4ae011f6db3020969205ceR72) to the [parsing phase](https://github.com/robert-bor/aho-corasick/blob/master/src/main/java/org/ahocorasick/trie/PayloadTrie.java#L188)
I think it's better to have consistent lower case conversion code across all stages rather than not, even if it's not perfect.
